### PR TITLE
Fix a rare panic that happens when visit_count is 0 and block NaN returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.DS_Store


### PR DESCRIPTION
I use ismcts in my [app for trick taking card games](https://github.com/dbravender/tricksterstable-rs) and noticed an extremely rare crash in the crash logs (something on the order of 1 out of every half a million simulations). I don't have the full traceback and I'm not sure what the reproduction steps are but I'm fairly certain this fixed it since this is the only place I could find where a division by zero panic can happen.